### PR TITLE
Make acceptedFileTypes optional

### DIFF
--- a/frontend/src/FileManager/Actions/UploadFile/UploadFile.action.jsx
+++ b/frontend/src/FileManager/Actions/UploadFile/UploadFile.action.jsx
@@ -31,8 +31,10 @@ const UploadFileAction = ({
   };
 
   const checkFileError = (file) => {
-    const extError = !acceptedFileTypes.includes(getFileExtension(file.name));
-    if (extError) return "File type is not allowed.";
+    if (acceptedFileTypes) {
+        const extError = !acceptedFileTypes.includes(getFileExtension(file.name));
+        if (extError) return "File type is not allowed.";
+    }
 
     const fileExists = currentPathFiles.some(
       (item) => item.name.toLowerCase() === file.name.toLowerCase() && !item.isDirectory


### PR DESCRIPTION
Hello. Thank you for releasing this awesome project - it's super useful! The only problem I've encountered with it is: it requires you to supply the `acceptedFileTypes` value. For my app, I needed to allow all types of files to be uploaded, and I think it's something more people might need. This pull request adds just that - it makes `acceptedFileTypes` optional.
