### PR TITLE
fix(current-path): prevent onFolderChange callback on initial path setter

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ if not specified.
 />
 ```
 
-## Custom File Preview
+## </> Custom File Preview
 
 The `FileManager` component allows you to provide a custom file preview by passing the
 `filePreviewComponent` prop. This is an optional callback function that receives the selected file
@@ -198,6 +198,43 @@ const CustomImagePreviewer = ({ file }) => {
   filePreviewComponent={(file) => <CustomImagePreviewer file={file} />}
 />;
 ```
+
+## 🧭 Handling Current Path
+
+By default, the file manager starts in the root directory (`""`). You can override this by passing
+an `initialPath` prop. For example, to start in `/Documents`:
+
+```jsx
+<FileManager initialPath="/Documents" />
+```
+
+### Controlled usage with `currentPath`
+
+If you want to **track and control** the current folder, you can pair `initialPath` with the
+`onFolderChange` callback. A common pattern is to keep the path in React state:
+
+```jsx
+import { useState } from "react";
+
+function App() {
+  const [currentPath, setCurrentPath] = useState("/Documents");
+
+  return (
+    <FileManager
+      // other props...
+      initialPath={currentPath}
+      onFolderChange={setCurrentPath}
+    />
+  );
+}
+```
+
+### Important notes
+
+- `initialPath` is applied **only once** when the `files` state is first set.
+- After that, folder changes are driven by `onFolderChange`.
+- If you want to keep the path in sync with user navigation, use a controlled state (as shown
+  above).
 
 ## 🤝 Contributing
 

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -176,7 +176,7 @@ if not specified.
 />
 ```
 
-## Custom File Preview
+## </> Custom File Preview
 
 The `FileManager` component allows you to provide a custom file preview by passing the
 `filePreviewComponent` prop. This is an optional callback function that receives the selected file
@@ -194,6 +194,43 @@ const CustomImagePreviewer = ({ file }) => {
   filePreviewComponent={(file) => <CustomImagePreviewer file={file} />}
 />;
 ```
+
+## 🧭 Handling Current Path
+
+By default, the file manager starts in the root directory (`""`). You can override this by passing
+an `initialPath` prop. For example, to start in `/Documents`:
+
+```jsx
+<FileManager initialPath="/Documents" />
+```
+
+### Controlled usage with `currentPath`
+
+If you want to **track and control** the current folder, you can pair `initialPath` with the
+`onFolderChange` callback. A common pattern is to keep the path in React state:
+
+```jsx
+import { useState } from "react";
+
+function App() {
+  const [currentPath, setCurrentPath] = useState("/Documents");
+
+  return (
+    <FileManager
+      // other props...
+      initialPath={currentPath}
+      onFolderChange={setCurrentPath}
+    />
+  );
+}
+```
+
+### Important notes
+
+- `initialPath` is applied **only once** when the `files` state is first set.
+- After that, folder changes are driven by `onFolderChange`.
+- If you want to keep the path in sync with user navigation, use a controlled state (as shown
+  above).
 
 ## ©️ License
 

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -14,6 +14,7 @@ function App() {
   };
   const [isLoading, setIsLoading] = useState(false);
   const [files, setFiles] = useState([]);
+  const [currentPath, setCurrentPath] = useState("");
   const isMountRef = useRef(false);
 
   // Get Files
@@ -162,7 +163,8 @@ function App() {
           acceptedFileTypes=".txt, .png, .jpg, .jpeg, .pdf, .doc, .docx, .exe"
           height="100%"
           width="100%"
-          initialPath=""
+          initialPath={currentPath}
+          onFolderChange={setCurrentPath}
         />
       </div>
     </div>

--- a/frontend/src/contexts/FileNavigationContext.jsx
+++ b/frontend/src/contexts/FileNavigationContext.jsx
@@ -27,12 +27,13 @@ export const FileNavigationProvider = ({ children, initialPath, onFolderChange }
 
   useEffect(() => {
     if (!isMountRef.current && Array.isArray(files) && files.length > 0) {
-      const activePath = files.some((file) => file.path === initialPath) ? initialPath : "";
+      const activePath = files.some((file) => file.isDirectory && file.path === initialPath)
+        ? initialPath
+        : "";
       setCurrentPath(activePath);
-      onFolderChange?.(activePath);
       isMountRef.current = true;
     }
-  }, [initialPath, files]);
+  }, [files]);
 
   return (
     <FileNavigationContext.Provider


### PR DESCRIPTION
- Add documentation for current path handling.
- Validate `isDirectory` for initial path.