### PR TITLE
Fix preview download navigation; clean up context menu config

### DIFF
--- a/frontend/src/FileManager/Actions/PreviewFile/PreviewFile.action.jsx
+++ b/frontend/src/FileManager/Actions/PreviewFile/PreviewFile.action.jsx
@@ -18,7 +18,7 @@ const iFrameExtensions = ["txt", "pdf"];
 const PreviewFileAction = ({ filePreviewPath, filePreviewComponent }) => {
   const [isLoading, setIsLoading] = useState(true);
   const [hasError, setHasError] = useState(false);
-  const { selectedFiles } = useSelection();
+  const { selectedFiles, handleDownload: triggerDownload } = useSelection();
   const fileIcons = useFileIcons(73);
   const extension = getFileExtension(selectedFiles[0].name)?.toLowerCase();
   const filePath = `${filePreviewPath}${selectedFiles[0].path}`;
@@ -41,7 +41,8 @@ const PreviewFileAction = ({ filePreviewPath, filePreviewComponent }) => {
   };
 
   const handleDownload = () => {
-    window.location.href = filePath;
+    // Delegate to host download handler so the main app controls download (no navigation)
+    triggerDownload();
   };
 
   if (React.isValidElement(customPreview)) {

--- a/frontend/src/FileManager/FileList/useFileList.jsx
+++ b/frontend/src/FileManager/FileList/useFileList.jsx
@@ -173,8 +173,7 @@ const useFileList = (onRefresh, enableFilePreview, triggerAction, permissions, o
       title: t("rename"),
       icon: <BiRename size={19} />,
       onClick: handleRenaming,
-      hidden: selectedFiles.length > 1,
-      hidden: !permissions.rename,
+      hidden: selectedFiles.length > 1 || !permissions.rename,
     },
     {
       title: t("download"),


### PR DESCRIPTION
**What was broken:** Clicking “Download” in the preview modal navigated the main window to the file URL (e.g., [/undefined/...)), breaking the app instead of triggering a download. The main toolbar download worked because it used the host’s [onDownload]; the preview bypassed it.
**Why it happened:** The preview download handler called [window.location.href = filePath], forcing full-page navigation and skipping the host download pipeline.
Secondary issue caught during build: Duplicate [hidden] keys in the context menu config caused a build error.
**Fix:** Delegate preview downloads to the host [onDownload] via [SelectionContext] and consolidate the [hidden]condition into one boolean.
**Result:** Preview download now behaves like the main download button—no navigation, host-controlled download; build error removed.